### PR TITLE
Remove the example code of what not to do

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,6 @@ contentLoaded.then(function () {
 
 Developers are strongly advised not to assign these promises to `document`, as the standard may still change substantially, and then such code would be future-incompatible.
 
-```js
-document.contentLoaded = contentLoaded;
-```
-
 ## FAQ
 
 ### What’s the difference between these promises and DOMContentLoaded?


### PR DESCRIPTION
In my experience, people tend to copy code examples without reading the surrounding text. So including an example of what not to do is bad; people are going to copy it.
